### PR TITLE
Test fixes

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "publish:latest": "lerna publish",
     "publish:next": "lerna publish --exact --canary=next --npm-tag=next --yes",
     "theia:start": "cd browser-app && yarn start",
-    "testcafe:start": "testcafe chrome:headless --no-sandbox --disable-dev-shm-usage tests/test.ts --skip-js-errors",
+    "testcafe:start": "testcafe chrome:headless --no-sandbox --disable-dev-shm-usage tests/test.ts --skip-js-errors -s takeOnFails=true,path=tests/screenshots",
     "e2etest": "npm-run-all --parallel --race --aggregate-output theia:start testcafe:start"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR solves the problems described in #8.

For the "Open UML.ecore"-Test, the elements that are counted were changed to the nodes instead of the names of the nodes, which should make it more robust.

The other two tests failed due to missing focus on the diagram. A helper method focus() was introduced, that should be called before DELETE is called in a test, to make sure that the focus is properly set.