### PR TITLE
Delete inheritance edges

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -50,7 +50,7 @@ done
 if [ "$buildBackend" == "true" ]; then
   echo "$(date +"[%T.%3N]") Build backend products"
   cd server/
-  mvn clean install -Pfatjar -U
+  mvn clean install -U
   cd ../
 fi
 

--- a/client/workspace/empty/model/empty.ecore
+++ b/client/workspace/empty/model/empty.ecore
@@ -1,46 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="testpackage" nsURI="testpackage" nsPrefix="testpackage">
-  <eClassifiers xsi:type="ecore:EClass" name="NewEClass0" eSuperTypes="//NewEClass1">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="neweclass1s" eType="//NewEClass1" eOpposite="//NewEClass1/neweclass0s"/>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" name="testpackage" nsURI="testpackage" nsPrefix="testpackage">
+  <eClassifiers xsi:type="ecore:EClass" name="NewEClass0" eSuperTypes="#//NewEClass1">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="neweclass1s" eType="#//NewEClass1"
+        eOpposite="#//NewEClass1/neweclass0s"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="NewEClass1" abstract="true">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="neweclass0s" eType="//NewEClass0" eOpposite="//NewEClass0/neweclass1s"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="neweclass0s" eType="#//NewEClass0"
+        eOpposite="#//NewEClass0/neweclass1s"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="NewEClass2" eSuperTypes="//NewEClass3"/>
+  <eClassifiers xsi:type="ecore:EClass" name="NewEClass2" eSuperTypes="#//NewEClass3"/>
   <eClassifiers xsi:type="ecore:EClass" name="NewEClass3" abstract="true"/>
   <eClassifiers xsi:type="ecore:EEnum" name="NewEEnum4">
-    <eLiterals name="red"/>
-    <eLiterals name="orange"/>
-    <eLiterals name="yellow"/>
-    <eLiterals name="green"/>
+    <eLiterals name="blue"/>
+    <eLiterals name="red" value="1"/>
+    <eLiterals name="orange" value="2"/>
+    <eLiterals name="yellow" value="3"/>
+    <eLiterals name="green" value="4"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="NewEClass5" interface="true"/>
-  <eClassifiers xsi:type="ecore:EClass" name="NewEClass6" eSuperTypes="//NewEClass5"/>
+  <eClassifiers xsi:type="ecore:EClass" name="NewEClass6" eSuperTypes="#//NewEClass5 #//NewEClass3"/>
   <eClassifiers xsi:type="ecore:EDataType" name="NewEDataType7" instanceClassName="java.lang.Object"/>
   <eClassifiers xsi:type="ecore:EClass" name="NewEClass8" abstract="true"/>
   <eClassifiers xsi:type="ecore:EClass" name="NewEClass9">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text" lowerBound="1">
-      <eType xsi:type="ecore:EDataType" href="http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text2" lowerBound="1">
-      <eType xsi:type="ecore:EDataType" href="http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
-    </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text3" lowerBound="1">
-      <eType xsi:type="ecore:EDataType" href="http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
-    </eStructuralFeatures>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text4" lowerBound="1">
-      <eType xsi:type="ecore:EDataType" href="http://www.eclipse.org/emf/2002/Ecore#//EDouble"/>
-    </eStructuralFeatures>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text2" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text3" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="text4" lowerBound="1" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EDouble"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="NewEClass10">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="neweclass11s" eType="//NewEClass11" eOpposite="//NewEClass11/neweclass10s"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="neweclass11s" eType="#//NewEClass11"
+        eOpposite="#//NewEClass11/neweclass10s"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="NewEClass11">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="neweclass10s" eType="//NewEClass10" eOpposite="//NewEClass10/neweclass11s"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="neweclass10s" eType="#//NewEClass10"
+        eOpposite="#//NewEClass10/neweclass11s"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="NewEClass12">
-    <eStructuralFeatures xsi:type="ecore:EReference" name="testreference" upperBound="-1" eType="//NewEClass8" containment="true" resolveProxies="false"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="containment" upperBound="-1"
+        eType="#//NewEClass8" containment="true" resolveProxies="false"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="NewEClass13"/>
-  <eClassifiers xsi:type="ecore:EClass" name="NewEClass14" abstract="true"/>
+  <eClassifiers xsi:type="ecore:EClass" name="NewEClass13" eSuperTypes="#//NewEClass14"/>
+  <eClassifiers xsi:type="ecore:EClass" name="NewEClass14" eSuperTypes="#//NewEClass13"/>
+  <eClassifiers xsi:type="ecore:EClass" name="NewEClass15">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="reference" eType="#//NewEClass14"/>
+  </eClassifiers>
 </ecore:EPackage>

--- a/client/workspace/empty/model/empty.enotation
+++ b/client/workspace/empty/model/empty.enotation
@@ -29,7 +29,7 @@
   <elements xsi:type="enotation:Shape">
     <semanticElement uri="//NewEEnum4"/>
     <position x="676.0" y="423.0"/>
-    <size width="158.609375" height="144.0"/>
+    <size width="158.609375" height="167.0"/>
   </elements>
   <elements xsi:type="enotation:Shape">
     <semanticElement uri="//NewEClass5"/>
@@ -83,12 +83,29 @@
   </elements>
   <elements xsi:type="enotation:Shape">
     <semanticElement uri="//NewEClass13"/>
-    <position x="982.0" y="505.0"/>
+    <position x="898.0" y="505.0"/>
     <size width="167.484375" height="43.0"/>
   </elements>
   <elements xsi:type="enotation:Shape">
     <semanticElement uri="//NewEClass14"/>
     <position x="1105.0" y="602.0"/>
     <size width="167.484375" height="43.0"/>
+  </elements>
+  <elements xsi:type="enotation:Shape">
+    <semanticElement uri="//NewEClass15"/>
+    <position x="825.0" y="671.0"/>
+    <size width="167.484375" height="43.0"/>
+  </elements>
+  <elements xsi:type="enotation:Edge">
+    <semanticElement uri="//NewEClass15/testreference"/>
+    <bendPoints x="875.7421875" y="688.5"/>
+    <bendPoints x="1185.2421875" y="688.5"/>
+  </elements>
+  <elements xsi:type="enotation:Edge">
+    <semanticElement uri="//NewEClass12/containment"/>
+  </elements>
+  <elements xsi:type="enotation:Edge">
+    <semanticElement uri="//NewEClass15/reference"/>
+    <bendPoints x="1188.7421875" y="691.5"/>
   </elements>
 </enotation:Diagram>

--- a/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/operationhandler/EcoreDeleteOperationHandler.java
+++ b/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/operationhandler/EcoreDeleteOperationHandler.java
@@ -11,14 +11,18 @@
 package org.eclipse.emfcloud.ecore.glsp.operationhandler;
 
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.eclipse.emf.ecore.EAttribute;
+import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EClassifier;
 import org.eclipse.emf.ecore.EEnumLiteral;
+import org.eclipse.emf.ecore.EGenericType;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emfcloud.ecore.glsp.model.EcoreModelServerAccess;
 import org.eclipse.emfcloud.ecore.glsp.model.EcoreModelState;
+import org.eclipse.emfcloud.ecore.glsp.util.EcoreEdgeUtil;
 import org.eclipse.glsp.server.model.GModelState;
 import org.eclipse.glsp.server.operations.DeleteOperation;
 import org.eclipse.glsp.server.protocol.GLSPServerException;
@@ -34,7 +38,7 @@ public class EcoreDeleteOperationHandler extends ModelServerAwareBasicOperationH
 
 			Optional<EObject> semantic = modelState.getIndex().getSemantic(elementId);
 
-			semantic.ifPresent(element -> {
+			semantic.ifPresentOrElse(element -> {
 				if (element instanceof EReference) {
 					if (!modelAccess.removeEReference(modelState, (EReference) element)) {
 						throw new GLSPServerException(
@@ -56,7 +60,27 @@ public class EcoreDeleteOperationHandler extends ModelServerAwareBasicOperationH
 								"Could not execute delete operation on EAttribute: " + element.toString());
 					}
 				}
-
+			}, () -> {
+				if (EcoreEdgeUtil.isGeneralizationEdge(elementId)) {
+					Optional<EObject> baseClass = modelState.getIndex()
+							.getSemantic(EcoreEdgeUtil.getBaseClassId(elementId));
+					baseClass.ifPresent(base -> {
+						Optional<EObject> superClass = modelState.getIndex()
+								.getSemantic(EcoreEdgeUtil.getSuperClassId(elementId));
+						superClass.ifPresent(superType -> {
+							if (base instanceof EClass && superType instanceof EClass
+									&& ((EClass) base).getESuperTypes().contains(superType)) {
+								EGenericType genericSuperType = ((EClass) base).getEGenericSuperTypes().stream()
+										.filter(t -> t.getEClassifier().equals(superType)).collect(Collectors.toList())
+										.get(0);
+								if (!modelAccess.removeESuperType(modelState, genericSuperType, (EClass) base)) {
+									throw new GLSPServerException("Could not execute delete operation on EGenericType: "
+											+ genericSuperType.toString());
+								}
+							}
+						});
+					});
+				}
 			});
 		});
 

--- a/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/util/EcoreEdgeUtil.java
+++ b/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/util/EcoreEdgeUtil.java
@@ -23,22 +23,5 @@ public class EcoreEdgeUtil {
 	public static String getEdgeId(String labelId) {
 		return labelId.split("_")[0];
 	}
-	
-	/**
-	*	Returns whether a graphic element ID resembles a generalization edge.
-	*	If edges are created for ESuperTypes, the graphic element IDs of the two involved classes are merged with a "_".
-	*	@see org.eclipse.emfcloud.ecore.glsp.gmodel.GModelFactory#create(org.eclipse.emf.ecore.EClass, org.eclipse.emf.ecore.EClass)
-	*/
-	public static boolean isGeneralizationEdge(String graphicElementId) {
-		return graphicElementId.contains("_");
-	}
-	
-	public static String getBaseClassId(String graphicElementId) {
-		return graphicElementId.split("_")[0];
-	}
-	
-	public static String getSuperClassId(String graphicElementId) {
-		return graphicElementId.split("_")[1];
-	}
 
 }

--- a/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/util/EcoreEdgeUtil.java
+++ b/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/util/EcoreEdgeUtil.java
@@ -23,5 +23,22 @@ public class EcoreEdgeUtil {
 	public static String getEdgeId(String labelId) {
 		return labelId.split("_")[0];
 	}
+	
+	/**
+	*	Returns whether a graphic element ID resembles a generalization edge.
+	*	If edges are created for ESuperTypes, the graphic element IDs of the two involved classes are merged with a "_".
+	*	@see org.eclipse.emfcloud.ecore.glsp.gmodel.GModelFactory#create(org.eclipse.emf.ecore.EClass, org.eclipse.emf.ecore.EClass)
+	*/
+	public static boolean isGeneralizationEdge(String graphicElementId) {
+		return graphicElementId.contains("_");
+	}
+	
+	public static String getBaseClassId(String graphicElementId) {
+		return graphicElementId.split("_")[0];
+	}
+	
+	public static String getSuperClassId(String graphicElementId) {
+		return graphicElementId.split("_")[1];
+	}
 
 }

--- a/server/org.eclipse.emfcloud.ecore.modelserver-app/org.eclipse.emfcloud.ecore.modelserver.product/Ecore-GLSP App.launch
+++ b/server/org.eclipse.emfcloud.ecore.modelserver-app/org.eclipse.emfcloud.ecore.modelserver.product/Ecore-GLSP App.launch
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.debug.core.groups.GroupLaunchConfigurationType">
+    <stringAttribute key="org.eclipse.debug.core.launchGroup.0.action" value="NONE"/>
+    <booleanAttribute key="org.eclipse.debug.core.launchGroup.0.adoptIfRunning" value="false"/>
+    <booleanAttribute key="org.eclipse.debug.core.launchGroup.0.enabled" value="true"/>
+    <stringAttribute key="org.eclipse.debug.core.launchGroup.0.mode" value="inherit"/>
+    <stringAttribute key="org.eclipse.debug.core.launchGroup.0.name" value="org.eclipse.emfcloud.ecore.glsp.product"/>
+    <stringAttribute key="org.eclipse.debug.core.launchGroup.1.action" value="NONE"/>
+    <booleanAttribute key="org.eclipse.debug.core.launchGroup.1.adoptIfRunning" value="false"/>
+    <booleanAttribute key="org.eclipse.debug.core.launchGroup.1.enabled" value="true"/>
+    <stringAttribute key="org.eclipse.debug.core.launchGroup.1.mode" value="inherit"/>
+    <stringAttribute key="org.eclipse.debug.core.launchGroup.1.name" value="org.eclipse.emfcloud.ecore.modelserver.product"/>
+</launchConfiguration>


### PR DESCRIPTION
- Retrieve base and superclass from inheritance edge graphical element id
--- Based on that, create remove command for eSuperType
- Improve safety of RemoveCommands
- Extend empty.ecore example
- Add Eclipse launch group configuration (starts modelserver and glsp server)
- Remove unnecessary 'fatjar' option from maven call in build.sh

Fixes #59 

Signed-off-by: Nina Doschek <ndoschek@eclipsesource.com>