### PR TITLE
Update dependencies

### DIFF
--- a/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/model/EcoreModelServerAccess.java
+++ b/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/model/EcoreModelServerAccess.java
@@ -81,7 +81,7 @@ public class EcoreModelServerAccess {
 	public void subscribe(NotificationSubscriptionListener<EObject> subscriptionListener) {
 		LOGGER.debug("EcoreModelServerAccess - subscribe");
 		this.subscriptionListener = subscriptionListener;
-		this.modelServerClient.subscribe(modelUri, subscriptionListener, "xmi");
+		this.modelServerClient.subscribe(modelUri, subscriptionListener, FORMAT_XMI);
 	}
 
 	public void unsubscribe() {

--- a/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/model/EcoreModelServerAccess.java
+++ b/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/model/EcoreModelServerAccess.java
@@ -81,7 +81,7 @@ public class EcoreModelServerAccess {
 	public void subscribe(NotificationSubscriptionListener<EObject> subscriptionListener) {
 		LOGGER.debug("EcoreModelServerAccess - subscribe");
 		this.subscriptionListener = subscriptionListener;
-		this.modelServerClient.subscribe(modelUri, subscriptionListener);
+		this.modelServerClient.subscribe(modelUri, subscriptionListener, "xmi");
 	}
 
 	public void unsubscribe() {

--- a/server/org.eclipse.emfcloud.ecore.modelserver/src/main/org/eclipse/emfcloud/ecore/modelserver/EcoreModelServerLauncher.java
+++ b/server/org.eclipse.emfcloud.ecore.modelserver/src/main/org/eclipse/emfcloud/ecore/modelserver/EcoreModelServerLauncher.java
@@ -15,6 +15,7 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.ecore.modelserver;
 
+import org.eclipse.emfcloud.modelserver.emf.di.DefaultModelServerModule;
 import org.eclipse.emfcloud.modelserver.emf.launch.ModelServerLauncher;
 
 import com.google.common.collect.Lists;
@@ -22,7 +23,7 @@ import com.google.common.collect.Lists;
 public class EcoreModelServerLauncher {
 
 	public static void main(String[] args) {
-		final ModelServerLauncher launcher = new ModelServerLauncher(args);
+		final ModelServerLauncher launcher = new ModelServerLauncher(args, new DefaultModelServerModule());
 		ModelServerLauncher.configureLogger();
 		launcher.addEPackageConfigurations(Lists.newArrayList(EcorePackageConfiguration.class));
 		launcher.start();

--- a/server/targetplatform/ecore-backend-app.target
+++ b/server/targetplatform/ecore-backend-app.target
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Ecore GLSP Codegen" sequenceNumber="1600690410">
+<target name="Ecore GLSP Codegen" sequenceNumber="1610111520">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.emf.ecore.feature.group" version="2.22.0.v20200519-1135"/>
-      <unit id="org.eclipse.emf.common.feature.group" version="2.19.0.v20200324-0932"/>
-      <unit id="org.eclipse.emf.codegen.ecore.feature.group" version="2.22.0.v20200324-0947"/>
-      <unit id="org.eclipse.core.runtime.feature.feature.group" version="1.2.900.v20200525-1407"/>
-      <unit id="org.eclipse.emf.codegen.feature.group" version="2.20.0.v20200324-0932"/>
-      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.800.v20200514-1529"/>
-      <unit id="com.ibm.icu" version="64.2.0.v20190507-1337"/>
-      <repository location="http://download.eclipse.org/releases/2020-06"/>
+      <unit id="org.eclipse.emf.ecore.feature.group" version="2.23.0.v20200630-0516"/>
+      <unit id="org.eclipse.emf.common.feature.group" version="2.20.0.v20200822-0801"/>
+      <unit id="org.eclipse.emf.codegen.ecore.feature.group" version="2.23.0.v20200701-0840"/>
+      <unit id="org.eclipse.core.runtime.feature.feature.group" version="1.2.1000.v20200828-1034"/>
+      <unit id="org.eclipse.emf.codegen.feature.group" version="2.21.0.v20200708-0547"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.900.v20200819-0940"/>
+      <unit id="com.ibm.icu" version="67.1.0.v20200706-1749"/>
+      <repository location="http://download.eclipse.org/releases/2020-09"/>
     </location>
   </locations>
 </target>

--- a/server/targetplatform/ecore-backend-app.tpd
+++ b/server/targetplatform/ecore-backend-app.tpd
@@ -2,13 +2,13 @@ target "Ecore GLSP Codegen" with requirements source
 
 // Target platform for the EMF Backend Application (EMF, Codegen)
 
-location "http://download.eclipse.org/releases/2020-06" {
+location "http://download.eclipse.org/releases/2020-09" {
 	org.eclipse.emf.ecore.feature.group [2.22.0,3.0.0)
 	org.eclipse.emf.common.feature.group [2.19.0,3.0.0)
 	org.eclipse.emf.codegen.ecore.feature.group [2.22.0,3.0.0)
 	org.eclipse.core.runtime.feature.feature.group [1.2.900,2.0.0)
 	org.eclipse.emf.codegen.feature.group [2.20.0,3.0.0)
 	org.eclipse.equinox.executable.feature.group [3.8.800,4.0.0)
-	com.ibm.icu [64.2.0,65.0.0)
+	com.ibm.icu [64.2.0,68.0.0)
 }
 

--- a/server/targetplatform/ecore-dev.target
+++ b/server/targetplatform/ecore-dev.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Ecore GLSP Dev" sequenceNumber="1607599725">
+<target name="Ecore GLSP Dev" sequenceNumber="1610111524">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.glsp.feature.feature.group" version="0.8.0.202010130847"/>
@@ -9,11 +9,11 @@
       <repository location="https://download.eclipse.org/glsp/server/p2/nightly/0.8/0.8.0.202010130847/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.elk.core" version="0.6.0"/>
-      <unit id="org.eclipse.elk.graph" version="0.6.0"/>
-      <unit id="org.eclipse.elk.graph.text" version="0.6.0"/>
-      <unit id="org.eclipse.elk.alg.layered" version="0.6.0"/>
-      <repository location="https://download.eclipse.org/elk/updates/releases/0.6.0/"/>
+      <unit id="org.eclipse.elk.core" version="0.7.0"/>
+      <unit id="org.eclipse.elk.graph" version="0.7.0"/>
+      <unit id="org.eclipse.elk.graph.text" version="0.7.0"/>
+      <unit id="org.eclipse.elk.alg.layered" version="0.7.0"/>
+      <repository location="https://download.eclipse.org/elk/updates/releases/0.7.0/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
@@ -30,11 +30,11 @@
       <unit id="org.hamcrest" version="1.1.0.v20090501071000"/>
       <unit id="org.slf4j.api" version="1.7.30.v20200204-2150"/>
       <unit id="javax.servlet" version="3.1.0.v201410161800"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200831200620/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.emfcloud.modelserver.feature.feature.group" version="0.7.0.202012091509"/>
-      <repository location="https://download.eclipse.org/emfcloud/modelserver/p2/nightly/"/>
+      <unit id="org.eclipse.emfcloud.modelserver.feature.feature.group" version="0.7.0.202101081124"/>
+      <repository location="https://download.eclipse.org/emfcloud/modelserver/p2/nightly/0.7/0.7.0.202101081124/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.emfjson.jackson" version="0.0.0"/>
@@ -42,21 +42,18 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.jetty.server" version="9.4.34.v20201102"/>
-      <unit id="org.eclipse.jetty.servlet" version="9.4.34.v20201102"/>
-      <unit id="org.eclipse.jetty.websocket.javax.websocket" version="9.4.34.v20201102"/>
-      <unit id="org.eclipse.jetty.websocket.server" version="9.4.34.v20201102"/>
       <repository location="https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.34.v20201102/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.emf.ecore.feature.group" version="2.22.0.v20200519-1135"/>
-      <unit id="org.eclipse.emf.common.feature.group" version="2.19.0.v20200324-0932"/>
-      <unit id="org.eclipse.emf.codegen.ecore.feature.group" version="2.22.0.v20200324-0947"/>
-      <unit id="org.eclipse.core.runtime.feature.feature.group" version="1.2.900.v20200525-1407"/>
-      <unit id="org.eclipse.emf.codegen.feature.group" version="2.20.0.v20200324-0932"/>
-      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.800.v20200514-1529"/>
-      <unit id="com.ibm.icu" version="64.2.0.v20190507-1337"/>
+      <unit id="org.eclipse.emf.ecore.feature.group" version="2.23.0.v20200630-0516"/>
+      <unit id="org.eclipse.emf.common.feature.group" version="2.20.0.v20200822-0801"/>
+      <unit id="org.eclipse.emf.codegen.ecore.feature.group" version="2.23.0.v20200701-0840"/>
+      <unit id="org.eclipse.core.runtime.feature.feature.group" version="1.2.1000.v20200828-1034"/>
+      <unit id="org.eclipse.emf.codegen.feature.group" version="2.21.0.v20200708-0547"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.900.v20200819-0940"/>
+      <unit id="com.ibm.icu" version="67.1.0.v20200706-1749"/>
       <unit id="org.eclipse.emf.edit" version="2.16.0.v20190920-0401"/>
-      <repository location="http://download.eclipse.org/releases/2020-06"/>
+      <repository location="http://download.eclipse.org/releases/2020-09"/>
     </location>
   </locations>
 </target>

--- a/server/targetplatform/ecore-server.target
+++ b/server/targetplatform/ecore-server.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Ecore GLSP Server" sequenceNumber="1607599842">
+<target name="Ecore GLSP Server" sequenceNumber="1610111493">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.glsp.feature.feature.group" version="0.8.0.202010130847"/>
@@ -9,17 +9,17 @@
       <repository location="https://download.eclipse.org/glsp/server/p2/nightly/0.8/0.8.0.202010130847/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.elk.core" version="0.6.0"/>
-      <unit id="org.eclipse.elk.graph" version="0.6.0"/>
-      <unit id="org.eclipse.elk.graph.text" version="0.6.0"/>
-      <unit id="org.eclipse.elk.alg.layered" version="0.6.0"/>
-      <repository location="https://download.eclipse.org/elk/updates/releases/0.6.0/"/>
+      <unit id="org.eclipse.elk.core" version="0.7.0"/>
+      <unit id="org.eclipse.elk.graph" version="0.7.0"/>
+      <unit id="org.eclipse.elk.graph.text" version="0.7.0"/>
+      <unit id="org.eclipse.elk.alg.layered" version="0.7.0"/>
+      <repository location="https://download.eclipse.org/elk/updates/releases/0.7.0/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.edit" version="2.16.0.v20190920-0401"/>
-      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.800.v20200514-1529"/>
-      <unit id="org.eclipse.core.runtime.feature.feature.group" version="1.2.900.v20200525-1407"/>
-      <repository location="http://download.eclipse.org/releases/2020-06"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.900.v20200819-0940"/>
+      <unit id="org.eclipse.core.runtime.feature.feature.group" version="1.2.1000.v20200828-1034"/>
+      <repository location="http://download.eclipse.org/releases/2020-09"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.apache.log4j" version="1.2.15.v201012070815"/>
@@ -36,11 +36,11 @@
       <unit id="org.hamcrest" version="1.1.0.v20090501071000"/>
       <unit id="org.slf4j.api" version="1.7.30.v20200204-2150"/>
       <unit id="javax.servlet" version="3.1.0.v201410161800"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200831200620/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.emfcloud.modelserver.feature.feature.group" version="0.7.0.202012091509"/>
-      <repository location="https://download.eclipse.org/emfcloud/modelserver/p2/nightly/"/>
+      <unit id="org.eclipse.emfcloud.modelserver.feature.feature.group" version="0.7.0.202101081124"/>
+      <repository location="https://download.eclipse.org/emfcloud/modelserver/p2/nightly/0.7/0.7.0.202101081124/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.emfjson.jackson" version="0.0.0"/>
@@ -48,9 +48,6 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.jetty.server" version="9.4.34.v20201102"/>
-      <unit id="org.eclipse.jetty.servlet" version="9.4.34.v20201102"/>
-      <unit id="org.eclipse.jetty.websocket.javax.websocket" version="9.4.34.v20201102"/>
-      <unit id="org.eclipse.jetty.websocket.server" version="9.4.34.v20201102"/>
       <repository location="https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.34.v20201102/"/>
     </location>
   </locations>

--- a/server/targetplatform/ecore-server.tpd
+++ b/server/targetplatform/ecore-server.tpd
@@ -7,21 +7,21 @@ location "https://download.eclipse.org/glsp/server/p2/nightly/0.8/0.8.0.20201013
 	org.eclipse.glsp.layout [0.8.0,0.9.0)
 }
 
-location "https://download.eclipse.org/elk/updates/releases/0.6.0/" {
-	org.eclipse.elk.core [0.6.0,1.0.0)
-	org.eclipse.elk.graph [0.6.0,1.0.0)
-	org.eclipse.elk.graph.text [0.6.0,1.0.0)
-	org.eclipse.elk.alg.layered [0.6.0,1.0.0)
+location "https://download.eclipse.org/elk/updates/releases/0.7.0/" {
+	org.eclipse.elk.core [0.7.0,1.0.0)
+	org.eclipse.elk.graph [0.7.0,1.0.0)
+	org.eclipse.elk.graph.text [0.7.0,1.0.0)
+	org.eclipse.elk.alg.layered [0.7.0,1.0.0)
 }
 
-location "http://download.eclipse.org/releases/2020-06" {
+location "http://download.eclipse.org/releases/2020-09" {
 	// Transitive dependencies + Eclipse Product
 	org.eclipse.emf.edit [2.16.0,3.0.0)
 	org.eclipse.equinox.executable.feature.group [3.8.600,4.0.0)
 	org.eclipse.core.runtime.feature.feature.group [1.2.900,2.0.0)
 }
 
-location "https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository/" {
+location "https://download.eclipse.org/tools/orbit/downloads/drops/R20200831200620/repository/" {
 	// Transitive dependencies
 	org.apache.log4j [1.2.15,2.0.0)
 	com.google.gson [2.7.0,2.7.1)
@@ -39,7 +39,7 @@ location "https://download.eclipse.org/tools/orbit/downloads/drops/R202005291911
 	javax.servlet [3.1.0,4.0.0)
 }
 
-location "https://download.eclipse.org/emfcloud/modelserver/p2/nightly/" {
+location "https://download.eclipse.org/emfcloud/modelserver/p2/nightly/0.7/0.7.0.202101081124/" {
 	org.eclipse.emfcloud.modelserver.feature.feature.group [0.7.0,0.8.0)
 }
 
@@ -49,7 +49,4 @@ location "http://ghillairet.github.io/p2" {
 
 location "https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.34.v20201102/" {
 	org.eclipse.jetty.server
-	org.eclipse.jetty.servlet
-	org.eclipse.jetty.websocket.javax.websocket
-	org.eclipse.jetty.websocket.server
 }


### PR DESCRIPTION
I updated to the latest modelserver nightly and aligned some other dependencies as well.
Now the timeout functionality should also work as expected in ecore-glsp.

Signed-off-by: Nina Doschek <ndoschek@eclipsesource.com>