### PR TITLE
Jenkins pipeline: Archive test artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,11 +78,17 @@ pipeline {
                 }
             }
         }
-        
         stage('Deploy (master only)') {
             when { branch 'master' }
             steps {
                 build job: 'deploy-ecore-glsp-npm', wait: false
+            }
+        }
+    }
+    post {
+        failure {
+            container('ci') {
+                archiveArtifacts artifacts: 'client/tests/results/**', fingerprint: true
             }
         }
     }

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
     "publish:latest": "lerna publish",
     "publish:next": "lerna publish --exact --canary=next --npm-tag=next --yes",
     "theia:start": "cd browser-app && yarn start",
-    "testcafe:start": "testcafe chrome:headless --no-sandbox --disable-dev-shm-usage tests/test.ts --skip-js-errors -s takeOnFails=true,path=tests/screenshots",
+    "testcafe:start": "testcafe chrome:headless --no-sandbox --disable-dev-shm-usage tests/test.ts --skip-js-errors -s takeOnFails=true,path=tests/results/screenshots",
     "e2etest": "npm-run-all --parallel --race --aggregate-output theia:start testcafe:start"
   },
   "devDependencies": {


### PR DESCRIPTION
- Archive test artifacts (testcafe screenshots) on build failures

[Build 16](https://ci.eclipse.org/emfcloud/job/eclipse-emfcloud/job/ecore-glsp/job/ndoschek%252Farchive-test-artifacts/16/) archived a screenshot of a failed e2e test (Test was modified temporarily to fail).

Signed-off-by: Nina Doschek <ndoschek@eclipsesource.com>