### PR TITLE
110: Unable to build because of missing Jetty dependency

### DIFF
--- a/server/targetplatform/ecore-dev.target
+++ b/server/targetplatform/ecore-dev.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Ecore GLSP Dev" sequenceNumber="1635154120">
+<target name="Ecore GLSP Dev" sequenceNumber="1636098419">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.glsp.feature.feature.group" version="0.9.0.202109211845"/>
@@ -43,7 +43,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.jetty.server" version="0.0.0"/>
       <unit id="org.eclipse.jetty.websocket.server" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.43.v20210629/"/>
+      <repository location="https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.44.v20210927/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.ecore.feature.group" version="2.24.0.v20210405-0628"/>

--- a/server/targetplatform/ecore-server.target
+++ b/server/targetplatform/ecore-server.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Ecore GLSP Server" sequenceNumber="1635154057">
+<target name="Ecore GLSP Server" sequenceNumber="1636098415">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.glsp.feature.feature.group" version="0.9.0.202109211845"/>
@@ -53,7 +53,7 @@
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.jetty.server" version="0.0.0"/>
       <unit id="org.eclipse.jetty.websocket.server" version="0.0.0"/>
-      <repository location="https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.43.v20210629/"/>
+      <repository location="https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.44.v20210927/"/>
     </location>
   </locations>
 </target>

--- a/server/targetplatform/ecore-server.tpd
+++ b/server/targetplatform/ecore-server.tpd
@@ -51,7 +51,7 @@ location "https://download.eclipse.org/emfcloud/emfjson-jackson/p2/nightly/1.3/1
 	org.eclipse.emfcloud.emfjson-jackson lazy
 }
 
-location "https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.43.v20210629/" {
+location "https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.44.v20210927/" {
 	org.eclipse.jetty.server lazy
 	org.eclipse.jetty.websocket.server lazy
 }


### PR DESCRIPTION
- Update the jetty P2 repo URL in the target platform

fixes #110