### PR TITLE
Add secondary license to LICENSE file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ kind: Pod
 spec:
   containers:
   - name: ci
-    image: eclipseglsp/ci:uitest
+    image: eclipseglsp/ci:uitest-v1.1
     tty: true
     resources:
       limits:
@@ -57,7 +57,9 @@ pipeline {
                 container('ci') {
                     timeout(15){
                         dir('client') {
-                            sh 'yarn install'
+                            withCredentials([string(credentialsId: "github-bot-token", variable: 'GITHUB_TOKEN')]) {
+                                sh 'yarn install'
+                            }
                         }
                     }
                 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,9 @@
-Eclipse Public License - v 2.0
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License v. 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+available at https://opensource.org/licenses/MIT.
+
+# Eclipse Public License - v 2.0
 
     THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
     PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
@@ -274,3 +279,26 @@ version(s), and exceptions or additional permissions here}."
   look for such a notice.
 
   You may add additional accurate notices of copyright ownership.
+
+---
+## The MIT License
+
+Copyright 2021 EclipseSource & others
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/client/packages/ecore-property-view/package.json
+++ b/client/packages/ecore-property-view/package.json
@@ -2,7 +2,7 @@
   "name": "@eclipse-emfcloud/ecore-property-view",
   "version": "0.2.0",
   "description": "Ecore property view",
-  "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
+  "license": "(EPL-2.0 OR MIT)",
   "keywords": [
     "theia-extension"
   ],

--- a/client/packages/ecore-property-view/src/browser/frontend-module.ts
+++ b/client/packages/ecore-property-view/src/browser/frontend-module.ts
@@ -3,15 +3,10 @@
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
  *
- * This Source Code may also be made available under the following Secondary
- * Licenses when the conditions for such availability set forth in the Eclipse
- * Public License v. 2.0 are satisfied: GNU General Public License, version 2
- * with the GNU Classpath Exception which is available at
- * https://www.gnu.org/software/classpath/license.html.
- *
- * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 import "../../style/jsonforms-styling.css";
 

--- a/client/packages/ecore-property-view/src/browser/property-data-service.ts
+++ b/client/packages/ecore-property-view/src/browser/property-data-service.ts
@@ -3,15 +3,10 @@
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
  *
- * This Source Code may also be made available under the following Secondary
- * Licenses when the conditions for such availability set forth in the Eclipse
- * Public License v. 2.0 are satisfied: GNU General Public License, version 2
- * with the GNU Classpath Exception which is available at
- * https://www.gnu.org/software/classpath/license.html.
- *
- * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 import { ecoreTypeSchema } from "@eclipse-emfcloud/ecore-glsp-common/lib/browser/ecore-json-schema";
 import { ModelServerPropertyDataService } from "@eclipse-emfcloud/modelserver-jsonforms-property-view";

--- a/client/packages/ecore-property-view/src/browser/utils.ts
+++ b/client/packages/ecore-property-view/src/browser/utils.ts
@@ -3,15 +3,10 @@
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
  *
- * This Source Code may also be made available under the following Secondary
- * Licenses when the conditions for such availability set forth in the Eclipse
- * Public License v. 2.0 are satisfied: GNU General Public License, version 2
- * with the GNU Classpath Exception which is available at
- * https://www.gnu.org/software/classpath/license.html.
- *
- * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 import { ModelServerClient } from "@eclipse-emfcloud/modelserver-theia";
 

--- a/client/packages/ecore-property-view/src/browser/widget-provider.ts
+++ b/client/packages/ecore-property-view/src/browser/widget-provider.ts
@@ -3,15 +3,10 @@
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
  *
- * This Source Code may also be made available under the following Secondary
- * Licenses when the conditions for such availability set forth in the Eclipse
- * Public License v. 2.0 are satisfied: GNU General Public License, version 2
- * with the GNU Classpath Exception which is available at
- * https://www.gnu.org/software/classpath/license.html.
- *
- * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 import { ModelserverAwareWidgetProvider } from "@eclipse-emfcloud/modelserver-jsonforms-property-view";
 import {

--- a/client/packages/sprotty-ecore/LICENSE
+++ b/client/packages/sprotty-ecore/LICENSE
@@ -1,4 +1,9 @@
-Eclipse Public License - v 2.0
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License v. 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+available at https://opensource.org/licenses/MIT.
+
+# Eclipse Public License - v 2.0
 
     THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
     PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
@@ -54,8 +59,7 @@ in any manner that enables the transfer of a copy.
 modifications, including but not limited to software source code,
 documentation source, and configuration files.
 
-"Secondary License" means either the GNU General Public License,
-Version 2.0, or any later versions of that license, including any
+"Secondary License" means either the MIT License or any
 exceptions or additional permissions as identified by the initial
 Contributor.
 
@@ -275,3 +279,26 @@ version(s), and exceptions or additional permissions here}."
   look for such a notice.
 
   You may add additional accurate notices of copyright ownership.
+
+---
+## The MIT License
+
+Copyright 2021 EclipseSource & others
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/client/packages/sprotty-ecore/src/action-definitions.ts
+++ b/client/packages/sprotty-ecore/src/action-definitions.ts
@@ -3,15 +3,10 @@
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
  *
- * This Source Code may also be made available under the following Secondary
- * Licenses when the conditions for such availability set forth in the Eclipse
- * Public License v. 2.0 are satisfied: GNU General Public License, version 2
- * with the GNU Classpath Exception which is available at
- * https://www.gnu.org/software/classpath/license.html.
- *
- * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 import { Action, generateRequestId, RequestAction, ResponseAction } from "@eclipse-glsp/client";
 

--- a/client/packages/sprotty-ecore/src/features/tool-palette/di.config.ts
+++ b/client/packages/sprotty-ecore/src/features/tool-palette/di.config.ts
@@ -3,15 +3,10 @@
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
  *
- * This Source Code may also be made available under the following Secondary
- * Licenses when the conditions for such availability set forth in the Eclipse
- * Public License v. 2.0 are satisfied: GNU General Public License, version 2
- * with the GNU Classpath Exception which is available at
- * https://www.gnu.org/software/classpath/license.html.
- *
- * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 import "@eclipse-glsp/client/css/tool-palette.css";
 import "@eclipse-glsp/theia-integration/css/tool-palette.css";

--- a/client/packages/sprotty-ecore/src/features/tool-palette/tool-palette.ts
+++ b/client/packages/sprotty-ecore/src/features/tool-palette/tool-palette.ts
@@ -3,15 +3,10 @@
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
  *
- * This Source Code may also be made available under the following Secondary
- * Licenses when the conditions for such availability set forth in the Eclipse
- * Public License v. 2.0 are satisfied: GNU General Public License, version 2
- * with the GNU Classpath Exception which is available at
- * https://www.gnu.org/software/classpath/license.html.
- *
- * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 import { compare, createToolGroup, PaletteItem, ToolPalette } from "@eclipse-glsp/client";
 import { injectable } from "inversify";

--- a/client/packages/theia-ecore/LICENSE
+++ b/client/packages/theia-ecore/LICENSE
@@ -1,4 +1,9 @@
-Eclipse Public License - v 2.0
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License v. 2.0 which is available at
+https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+available at https://opensource.org/licenses/MIT.
+
+# Eclipse Public License - v 2.0
 
     THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
     PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
@@ -54,8 +59,7 @@ in any manner that enables the transfer of a copy.
 modifications, including but not limited to software source code,
 documentation source, and configuration files.
 
-"Secondary License" means either the GNU General Public License,
-Version 2.0, or any later versions of that license, including any
+"Secondary License" means either the MIT License or any
 exceptions or additional permissions as identified by the initial
 Contributor.
 
@@ -275,3 +279,26 @@ version(s), and exceptions or additional permissions here}."
   look for such a notice.
 
   You may add additional accurate notices of copyright ownership.
+
+---
+## The MIT License
+
+Copyright 2021 EclipseSource & others
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/client/packages/theia-ecore/src/browser/diagram/selection-data-service.ts
+++ b/client/packages/theia-ecore/src/browser/diagram/selection-data-service.ts
@@ -3,15 +3,10 @@
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
- * http://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
  *
- * This Source Code may also be made available under the following Secondary
- * Licenses when the conditions for such availability set forth in the Eclipse
- * Public License v. 2.0 are satisfied: GNU General Public License, version 2
- * with the GNU Classpath Exception which is available at
- * https://www.gnu.org/software/classpath/license.html.
- *
- * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 import {
     isSetSemanticUriAction,

--- a/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/model/EcoreModelServerSubscriptionListener.java
+++ b/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/model/EcoreModelServerSubscriptionListener.java
@@ -1,18 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2020-2021 EclipseSource and others.
  *  
- *   This program and the accompanying materials are made available under the
- *   terms of the Eclipse Public License v. 2.0 which is available at
- *   http://www.eclipse.org/legal/epl-2.0.
- *  
- *   This Source Code may also be made available under the following Secondary
- *   Licenses when the conditions for such availability set forth in the Eclipse
- *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
- *   with the GNU Classpath Exception which is available at
- *   https://www.gnu.org/software/classpath/license.html.
- *  
- *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
- ******************************************************************************/
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
 package org.eclipse.emfcloud.ecore.glsp.model;
 
 import java.util.Optional;

--- a/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/operationhandler/ModelServerAwareBasicCreateOperationHandler.java
+++ b/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/operationhandler/ModelServerAwareBasicCreateOperationHandler.java
@@ -1,18 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2020 EclipseSource and others.
- *  
- *   This program and the accompanying materials are made available under the
- *   terms of the Eclipse Public License v. 2.0 which is available at
- *   http://www.eclipse.org/legal/epl-2.0.
- *  
- *   This Source Code may also be made available under the following Secondary
- *   Licenses when the conditions for such availability set forth in the Eclipse
- *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
- *   with the GNU Classpath Exception which is available at
- *   https://www.gnu.org/software/classpath/license.html.
- *  
- *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
- ******************************************************************************/
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
 package org.eclipse.emfcloud.ecore.glsp.operationhandler;
 
 import java.util.List;

--- a/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/operationhandler/ModelServerAwareBasicOperationHandler.java
+++ b/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/operationhandler/ModelServerAwareBasicOperationHandler.java
@@ -1,18 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2020 EclipseSource and others.
- *  
- *   This program and the accompanying materials are made available under the
- *   terms of the Eclipse Public License v. 2.0 which is available at
- *   http://www.eclipse.org/legal/epl-2.0.
- *  
- *   This Source Code may also be made available under the following Secondary
- *   Licenses when the conditions for such availability set forth in the Eclipse
- *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
- *   with the GNU Classpath Exception which is available at
- *   https://www.gnu.org/software/classpath/license.html.
- *  
- *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
- ******************************************************************************/
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
 package org.eclipse.emfcloud.ecore.glsp.operationhandler;
 
 import org.eclipse.emfcloud.ecore.glsp.model.EcoreModelServerAccess;

--- a/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/operationhandler/ModelserverAwareOperationHandler.java
+++ b/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/operationhandler/ModelserverAwareOperationHandler.java
@@ -1,18 +1,13 @@
 /*******************************************************************************
  * Copyright (c) 2019 EclipseSource and others.
- *  
- *   This program and the accompanying materials are made available under the
- *   terms of the Eclipse Public License v. 2.0 which is available at
- *   http://www.eclipse.org/legal/epl-2.0.
- *  
- *   This Source Code may also be made available under the following Secondary
- *   Licenses when the conditions for such availability set forth in the Eclipse
- *   Public License v. 2.0 are satisfied: GNU General Public License, version 2
- *   with the GNU Classpath Exception which is available at
- *   https://www.gnu.org/software/classpath/license.html.
- *  
- *   SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
- ******************************************************************************/
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
 package org.eclipse.emfcloud.ecore.glsp.operationhandler;
 
 import org.eclipse.emfcloud.ecore.glsp.model.EcoreModelServerAccess;

--- a/server/org.eclipse.emfcloud.ecore.modelserver/src/main/java/org/eclipse/emfcloud/ecore/modelserver/EcoreModelServerLauncher.java
+++ b/server/org.eclipse.emfcloud.ecore.modelserver/src/main/java/org/eclipse/emfcloud/ecore/modelserver/EcoreModelServerLauncher.java
@@ -3,15 +3,10 @@
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
  *
- * This Source Code may also be made available under the following Secondary
- * Licenses when the conditions for such availability set forth in the Eclipse
- * Public License v. 2.0 are satisfied: GNU General Public License, version 2
- * with the GNU Classpath Exception which is available at
- * https://www.gnu.org/software/classpath/license.html.
- *
- * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 package org.eclipse.emfcloud.ecore.modelserver;
 

--- a/server/org.eclipse.emfcloud.ecore.modelserver/src/main/java/org/eclipse/emfcloud/ecore/modelserver/EnotationPackageConfiguration.java
+++ b/server/org.eclipse.emfcloud.ecore.modelserver/src/main/java/org/eclipse/emfcloud/ecore/modelserver/EnotationPackageConfiguration.java
@@ -3,15 +3,10 @@
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
- * https://www.eclipse.org/legal/epl-2.0.
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
  *
- * This Source Code may also be made available under the following Secondary
- * Licenses when the conditions for such availability set forth in the Eclipse
- * Public License v. 2.0 are satisfied: GNU General Public License, version 2
- * with the GNU Classpath Exception which is available at
- * https://www.gnu.org/software/classpath/license.html.
- *
- * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
 package org.eclipse.emfcloud.ecore.modelserver;
 


### PR DESCRIPTION
- Align all licenses to use MIT as secondary license
- As this project was initially based on other projects, the usage of the GPL license were copy paste mistakes. The initial setup of the project forsaw to use MIT as secondary license