### PR TITLE
115: Error when creating any node

### DIFF
--- a/server/org.eclipse.emfcloud.ecore.modelserver/src/main/java/org/eclipse/emfcloud/ecore/modelserver/EcoreModelResourceManager.java
+++ b/server/org.eclipse.emfcloud.ecore.modelserver/src/main/java/org/eclipse/emfcloud/ecore/modelserver/EcoreModelResourceManager.java
@@ -33,6 +33,7 @@ import org.eclipse.emfcloud.ecore.enotation.NotationElement;
 import org.eclipse.emfcloud.ecore.enotation.SemanticProxy;
 import org.eclipse.emfcloud.ecore.enotation.Shape;
 import org.eclipse.emfcloud.modelserver.emf.common.DefaultModelResourceManager;
+import org.eclipse.emfcloud.modelserver.emf.common.watchers.ModelWatchersManager;
 import org.eclipse.emfcloud.modelserver.emf.configuration.EPackageConfiguration;
 import org.eclipse.emfcloud.modelserver.emf.configuration.ServerConfiguration;
 import org.eclipse.glsp.graph.util.GraphUtil;
@@ -51,8 +52,8 @@ public class EcoreModelResourceManager extends DefaultModelResourceManager {
 
 	@Inject
 	public EcoreModelResourceManager(Set<EPackageConfiguration> configurations, AdapterFactory adapterFactory,
-			ServerConfiguration serverConfiguration) {
-		super(configurations, adapterFactory, serverConfiguration);
+			ServerConfiguration serverConfiguration, final ModelWatchersManager watchersManager) {
+		super(configurations, adapterFactory, serverConfiguration, watchersManager);
 	}
 
 	@Override

--- a/server/targetplatform/ecore-dev.target
+++ b/server/targetplatform/ecore-dev.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Ecore GLSP Dev" sequenceNumber="1636098419">
+<target name="Ecore GLSP Dev" sequenceNumber="1638803343">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.glsp.feature.feature.group" version="0.9.0.202109211845"/>
@@ -33,8 +33,8 @@
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.emfcloud.modelserver.feature.feature.group" version="0.7.0.202110081257"/>
-      <repository location="https://download.eclipse.org/emfcloud/modelserver/p2/nightly/0.7/0.7.0.202110081257/"/>
+      <unit id="org.eclipse.emfcloud.modelserver.feature.feature.group" version="0.7.0.202112021704"/>
+      <repository location="https://download.eclipse.org/emfcloud/modelserver/p2/nightly/0.7/0.7.0.202112021704/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emfcloud.emfjson-jackson" version="0.0.0"/>

--- a/server/targetplatform/ecore-server.target
+++ b/server/targetplatform/ecore-server.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Ecore GLSP Server" sequenceNumber="1636098415">
+<target name="Ecore GLSP Server" sequenceNumber="1638803340">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.glsp.feature.feature.group" version="0.9.0.202109211845"/>
@@ -43,8 +43,8 @@
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.emfcloud.modelserver.feature.feature.group" version="0.7.0.202110081257"/>
-      <repository location="https://download.eclipse.org/emfcloud/modelserver/p2/nightly/0.7/0.7.0.202110081257/"/>
+      <unit id="org.eclipse.emfcloud.modelserver.feature.feature.group" version="0.7.0.202112021704"/>
+      <repository location="https://download.eclipse.org/emfcloud/modelserver/p2/nightly/0.7/0.7.0.202112021704/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emfcloud.emfjson-jackson" version="0.0.0"/>

--- a/server/targetplatform/ecore-server.tpd
+++ b/server/targetplatform/ecore-server.tpd
@@ -43,7 +43,7 @@ location "https://download.eclipse.org/tools/orbit/downloads/drops/R202106020316
 	org.slf4j.api [1.7.30,2.0.0)
 }
 
-location "https://download.eclipse.org/emfcloud/modelserver/p2/nightly/0.7/0.7.0.202110081257/" {
+location "https://download.eclipse.org/emfcloud/modelserver/p2/nightly/0.7/0.7.0.202112021704/" {
 	org.eclipse.emfcloud.modelserver.feature.feature.group [0.7.0,1.0.0)
 }
 


### PR DESCRIPTION
- Update the ModelServer to include thread-safe patches

Note: If the properties view is open when creating a new Class in GLSP, we now have a different exception. This additional exception doesn't occur all the time (Maybe 75% of the time), and doesn't affect the diagram. It doesn't seem to break the properties view, either. Not sure what's going on here:

```
830670 [SingleThreadModelController 1] ERROR ContextResponse  - An error occurred during data decoding
org.eclipse.emfcloud.modelserver.common.codecs.DecodingException: 
	at org.eclipse.emfcloud.modelserver.common.codecs.DefaultJsonCodec.decode(DefaultJsonCodec.java:62)
	at org.eclipse.emfcloud.modelserver.emf.common.codecs.DICodecsManager.decode(DICodecsManager.java:101)
	at org.eclipse.emfcloud.modelserver.emf.common.DefaultModelController.readPayload(DefaultModelController.java:270)
	at org.eclipse.emfcloud.modelserver.emf.common.DefaultModelController.executeCommand(DefaultModelController.java:284)
	at org.eclipse.emfcloud.modelserver.emf.common.SingleThreadModelController.lambda$13(SingleThreadModelController.java:164)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at org.eclipse.emfcloud.modelserver.emf.common.SingleThreadModelController.handleAction(SingleThreadModelController.java:88)
	at org.eclipse.emfcloud.modelserver.emf.common.SingleThreadModelController.handleNextAction(SingleThreadModelController.java:82)
	at org.eclipse.emfcloud.modelserver.emf.common.SingleThreadModelController.runThread(SingleThreadModelController.java:68)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: org.eclipse.emfcloud.jackson.errors.JSONException: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.lang.String` from Array value (token `JsonToken.START_ARRAY`)
 at [Source: (ByteArrayInputStream); line: 1, column: 283] (through reference chain: org.eclipse.emf.ecore.util.EDataTypeUniqueEList[0])
	... 11 more
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.lang.String` from Array value (token `JsonToken.START_ARRAY`)
 at [Source: (ByteArrayInputStream); line: 1, column: 283] (through reference chain: org.eclipse.emf.ecore.util.EDataTypeUniqueEList[0])
	at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:59)
	at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1601)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1375)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1280)
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer._parseString(StdDeserializer.java:1288)
	at com.fasterxml.jackson.databind.deser.std.StringCollectionDeserializer.deserialize(StringCollectionDeserializer.java:216)
	at com.fasterxml.jackson.databind.deser.std.StringCollectionDeserializer.deserialize(StringCollectionDeserializer.java:25)
	at org.eclipse.emfcloud.jackson.databind.property.EObjectFeatureProperty.deserializeAndSet(EObjectFeatureProperty.java:76)
	at org.eclipse.emfcloud.jackson.databind.deser.EObjectDeserializer.deserialize(EObjectDeserializer.java:79)
	at org.eclipse.emfcloud.jackson.databind.deser.EObjectDeserializer.deserialize(EObjectDeserializer.java:38)
	at org.eclipse.emfcloud.jackson.databind.deser.ResourceDeserializer.deserialize(ResourceDeserializer.java:75)
	at org.eclipse.emfcloud.jackson.databind.deser.ResourceDeserializer.deserialize(ResourceDeserializer.java:30)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:324)
	at com.fasterxml.jackson.databind.ObjectReader._bindAndClose(ObjectReader.java:2033)
	at com.fasterxml.jackson.databind.ObjectReader.readValue(ObjectReader.java:1426)
	at org.eclipse.emfcloud.jackson.resource.JsonResource.doLoad(JsonResource.java:192)
	at org.eclipse.emf.ecore.resource.impl.ResourceImpl.load(ResourceImpl.java:1563)
	at org.eclipse.emfcloud.modelserver.common.codecs.DefaultJsonCodec.decode(DefaultJsonCodec.java:60)
	... 10 more
```