### PR TITLE
114: EMF generator generations fails

### DIFF
--- a/client/packages/theia-ecore/src/node/ecore-file-generation.ts
+++ b/client/packages/theia-ecore/src/node/ecore-file-generation.ts
@@ -92,8 +92,10 @@ export class EcoreFileGenServer implements FileGenServer, BackendApplicationCont
 
     generateCode(genmodelPath: string, workspacePath: string): Promise<string> {
         const args: string[] = [
+            // Eclipse Args
             "-data", workspacePath,
             "-application", "org.eclipse.emfcloud.ecore.backend.app.codegen",
+            // Codegen App Args
             genmodelPath
         ];
 
@@ -139,6 +141,9 @@ export class EcoreFileGenServer implements FileGenServer, BackendApplicationCont
     }
 
     private spawnProcess(command: string, args?: string[]): RawProcess | undefined {
+        console.log("Spawn process:");
+        console.log("Command: " + command);
+        console.log("Args: ", args);
         const rawProcess = this.processFactory({ command, args });
         if (rawProcess.process === undefined) {
             return undefined;

--- a/server/org.eclipse.emfcloud.ecore.backend-app/org.eclipse.emfcloud.ecore.backend.app/META-INF/MANIFEST.MF
+++ b/server/org.eclipse.emfcloud.ecore.backend-app/org.eclipse.emfcloud.ecore.backend.app/META-INF/MANIFEST.MF
@@ -6,5 +6,7 @@ Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: ecore.glsp.backend.app
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.equinox.app,
- org.eclipse.emf.codegen.ecore;bundle-version="2.20.0"
+ org.eclipse.emf.codegen.ecore;bundle-version="2.20.0",
+ org.eclipse.core.resources;bundle-version="3.15.0",
+ org.eclipse.core.runtime;bundle-version="3.22.0"
 Export-Package: org.eclipse.emfcloud.ecore.backend.app

--- a/server/org.eclipse.emfcloud.ecore.backend-app/org.eclipse.emfcloud.ecore.codegen.product/org.eclipse.emfcloud.ecore.codegen.product
+++ b/server/org.eclipse.emfcloud.ecore.backend-app/org.eclipse.emfcloud.ecore.codegen.product/org.eclipse.emfcloud.ecore.codegen.product
@@ -32,6 +32,7 @@
    </features>
 
    <configurations>
+      <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="0" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.ds" autoStart="true" startLevel="2" />

--- a/server/org.eclipse.emfcloud.ecore.glsp-app/org.eclipse.emfcloud.ecore.glsp.product/org.eclipse.emfcloud.ecore.glsp.product.launch
+++ b/server/org.eclipse.emfcloud.ecore.glsp-app/org.eclipse.emfcloud.ecore.glsp.product/org.eclipse.emfcloud.ecore.glsp.product.launch
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
     <setAttribute key="additional_plugins">
-        <setEntry value="org.eclipse.core.runtime:3.19.0.v20200724-1004:default:true:default:true"/>
-        <setEntry value="org.eclipse.equinox.common:3.13.0.v20200828-1034:default:true:2:true"/>
-        <setEntry value="org.eclipse.equinox.ds:1.6.200.v20200422-1833:default:true:2:true"/>
-        <setEntry value="org.eclipse.equinox.simpleconfigurator:1.3.600.v20200721-1308:default:true:1:true"/>
-        <setEntry value="org.eclipse.osgi:3.16.0.v20200828-0759:default:true:default:true"/>
+        <setEntry value="org.eclipse.core.runtime:3.22.0.v20210506-1025:default:true:default:true"/>
+        <setEntry value="org.eclipse.equinox.common:3.15.0.v20210518-0604:default:true:2:true"/>
+        <setEntry value="org.eclipse.equinox.simpleconfigurator:1.4.0.v20210315-2228:default:true:1:true"/>
+        <setEntry value="org.eclipse.osgi:3.16.300.v20210525-1715:default:true:default:true"/>
     </setAttribute>
     <booleanAttribute key="append.args" value="true"/>
     <stringAttribute key="application" value="org.eclipse.emfcloud.ecore.glsp.app.ecore-glsp-server"/>
@@ -23,6 +22,7 @@
     <stringAttribute key="featurePluginResolution" value="workspace"/>
     <booleanAttribute key="includeOptional" value="true"/>
     <stringAttribute key="location" value="${workspace_loc}/../runtime-org.eclipse.emfcloud.ecore.glsp.product"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -nosplash"/>

--- a/server/org.eclipse.emfcloud.ecore.modelserver-app/org.eclipse.emfcloud.ecore.modelserver.product/org.eclipse.emfcloud.ecore.modelserver.product.launch
+++ b/server/org.eclipse.emfcloud.ecore.modelserver-app/org.eclipse.emfcloud.ecore.modelserver.product/org.eclipse.emfcloud.ecore.modelserver.product.launch
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
     <setAttribute key="additional_plugins">
-        <setEntry value="org.apache.felix.scr:2.1.16.v20200110-1820:default:true:2:true"/>
-        <setEntry value="org.eclipse.core.runtime:3.19.0.v20200724-1004:default:true:default:true"/>
-        <setEntry value="org.eclipse.equinox.common:3.13.0.v20200828-1034:default:true:2:true"/>
-        <setEntry value="org.eclipse.equinox.ds:1.6.200.v20200422-1833:default:true:2:true"/>
-        <setEntry value="org.eclipse.equinox.simpleconfigurator:1.3.600.v20200721-1308:default:true:1:true"/>
-        <setEntry value="org.eclipse.osgi:3.16.0.v20200828-0759:default:true:default:true"/>
+        <setEntry value="org.apache.felix.scr:2.1.24.v20200924-1939:default:true:2:true"/>
+        <setEntry value="org.eclipse.core.runtime:3.22.0.v20210506-1025:default:true:default:true"/>
+        <setEntry value="org.eclipse.equinox.common:3.15.0.v20210518-0604:default:true:2:true"/>
+        <setEntry value="org.eclipse.equinox.simpleconfigurator:1.4.0.v20210315-2228:default:true:1:true"/>
+        <setEntry value="org.eclipse.osgi:3.16.300.v20210525-1715:default:true:default:true"/>
     </setAttribute>
     <booleanAttribute key="append.args" value="true"/>
     <stringAttribute key="application" value="org.eclipse.emfcloud.ecore.modelserver.app.ecore-glsp-modelserver"/>
@@ -25,6 +24,7 @@
     <stringAttribute key="featurePluginResolution" value="workspace"/>
     <booleanAttribute key="includeOptional" value="true"/>
     <stringAttribute key="location" value="${workspace_loc}/../runtime-org.eclipse.emfcloud.ecore.modelserver.product"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -nosplash"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>


### PR DESCRIPTION
- Fix the backend product configuration

There is still an issue with the code generator: it only works once. There are several causes (yet to be investigated):

- EMF Code is generated as an Eclipse Project, with associated metadata (.metadata/, .project). If the .project is removed, the project becomes invalid and the generation will fail (Workaround: also delete .metadata/ to start on a clean Eclipse Workspace)
- If the .metadata/.project are still present, the generator fails with a NPE

This is mostly related to this old issue from the archived repo: https://github.com/eclipse-emfcloud/ecore-glsp/issues/117

It would make it easier to separate the Backend/EMF Workspace from the Theia Workspace, and that would cause less interferences