### PR TITLE
Fixed Dockerfile and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ Make sure to only build the backend (and not the front-end). This is needed befo
 
 ### Building docker image
 
-Build the docker image using the following command, where <imagename> and <tagname> are replaced with the values you wish to use.
+Build the docker image using the following command, where &lt;imagename&gt; and &lt;tagname&gt; are replaced with the values you wish to use.
 `docker build -t <imagename>:<tagname> .`
 
 For example: `docker build -t ecore-glsp .`
 
 ### Running in docker
 
-When the docker image is build, you can start the container using the following command (where again the <imagename> and <tagename> are replaced).
+When the docker image is build, you can start the container using the following command (where again the &lt;imagename&gt; and &lt;tagename&gt; are replaced).
 
 `docker run -it -p 3000:3000 --rm <imagename>:<tagname>`
 

--- a/README.md
+++ b/README.md
@@ -39,12 +39,18 @@ The client repo contains a [Dockerfile](client/README.md), that builds the entir
 
 For installing docker locally please consult [docker's installation description](https://docs.docker.com/install/) for your OS.
 
-**The glsp-server needs to be build locally before you build the image**
+**Locally build backend only**
+Make sure to only build the backend (and not the front-end). This is needed before building the docker image.
+`build.sh -b`
 
-**Building**
-`docker build -t <imagename>:<tagname> .` 
+**Building docker image**
+`docker build -t <imagename>:<tagname> .`
 
-**Running**
+For example: `docker build -t ecore-glsp .`
+
+**Running in docker**
 `docker run -it -p 3000:3000 --rm <imagename>:<tagname>`
 
-After that you should be able to connect with your browser at localhost:3000.	
+For example: `docker run -it -p 3000:3000 --rm ecore-glsp`
+
+After that you should be able to connect with your browser at localhost:3000.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Make sure to only build the backend (and not the front-end). This is needed befo
 ### Building docker image
 
 Build the docker image using the following command, where &lt;imagename&gt; and &lt;tagname&gt; are replaced with the values you wish to use.
+
 `docker build -t <imagename>:<tagname> .`
 
 For example: `docker build -t ecore-glsp .`

--- a/README.md
+++ b/README.md
@@ -39,18 +39,25 @@ The client repo contains a [Dockerfile](client/README.md), that builds the entir
 
 For installing docker locally please consult [docker's installation description](https://docs.docker.com/install/) for your OS.
 
-**Locally build backend only**
+### Locally build backend
+
 Make sure to only build the backend (and not the front-end). This is needed before building the docker image.
+
 `build.sh -b`
 
-**Building docker image**
+### Building docker image
+
+Build the docker image using the following command, where <imagename> and <tagname> are replaced with the values you wish to use.
 `docker build -t <imagename>:<tagname> .`
 
 For example: `docker build -t ecore-glsp .`
 
-**Running in docker**
+### Running in docker
+
+When the docker image is build, you can start the container using the following command (where again the <imagename> and <tagename> are replaced).
+
 `docker run -it -p 3000:3000 --rm <imagename>:<tagname>`
 
 For example: `docker run -it -p 3000:3000 --rm ecore-glsp`
 
-After that you should be able to connect with your browser at localhost:3000.
+After that you should be able to connect with your browser at http://localhost:3000.

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,12 +1,13 @@
-FROM node:10.18.0-alpine3.10
+FROM node:12.22.9-alpine3.15
 
 RUN mkdir /usr/src/client -p
 
 WORKDIR /usr/src/client
 
-RUN apk add --update python && \ 
+RUN apk add --update python3 && \
 	apk add --update make && \
-	apk add --update g++ && \ 
+	apk add --update g++ && \
+	apk add --update libsecret-dev && \
 	apk add --update openjdk11-jre
 
 # Have to copy everything because the build statement in theia-ecore starts linting, which requires all files.


### PR DESCRIPTION
Since I wanted to try the ecore-glsp client on Windows it's easiest to use docker. I couldn't get the container to build, and I think it's because the Dockerfile isn't updated for a while. I updated the node server to 12 and added the missing OS dependencies while creating the image.

Now the container is building and starting correctly. I guess this is usefull for all users who simply want to test the editor without installing all build dependencies on their machine.