### PR TITLE
#112: Error on starting example on Windows

### DIFF
--- a/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/model/EcoreModelState.java
+++ b/server/org.eclipse.emfcloud.ecore.glsp/src/main/java/org/eclipse/emfcloud/ecore/glsp/model/EcoreModelState.java
@@ -11,6 +11,7 @@
 package org.eclipse.emfcloud.ecore.glsp.model;
 
 import org.eclipse.emf.common.command.BasicCommandStack;
+import org.eclipse.emf.common.util.URI;
 import org.eclipse.emfcloud.ecore.enotation.Diagram;
 import org.eclipse.emfcloud.ecore.glsp.EcoreEditorContext;
 import org.eclipse.emfcloud.ecore.glsp.EcoreFacade;
@@ -77,9 +78,7 @@ public class EcoreModelState extends GModelStateImpl implements GModelState {
 	public String getModelUri() {
 		String sourceURI = MapUtil.getValue(getClientOptions(), ClientOptions.SOURCE_URI)
 				.orElseThrow(() -> new GLSPServerException("No source uri given to load model!"));
-		String workspaceRoot = MapUtil.getValue(getClientOptions(), WORKSPACE_ROOT_OPTION)
-				.orElseThrow(() -> new GLSPServerException("No workspaceUri given to load model!"));
-		return sourceURI.replace(workspaceRoot.replaceFirst("file://", ""), "").replaceFirst("/", "");
+		return URI.createFileURI(sourceURI).toString();
 	}
 
 	@Override


### PR DESCRIPTION
- Change EcoreModelState to use complete EMF URI instead of file path, so it can be reliably interpreted by the ModelServer

Instead of file path:

`/home/.../workspace/project/folder/fileName`

Use absolute URI:

`file:/home/.../workspace/project/folder/fileName`

Or, on Windows:

`file:/c:/...workspace/project/folder/fileName`

Note: this fixes the issue specifically for EcoreGLSP on Windows, but I've opened eclipse-emfcloud/emfcloud-modelserver/issues/155 to formally specify how ModelURIs should be handled in the future (As we're currently using a mix of file paths, relative URIs and absolute URIs).